### PR TITLE
Fix OPA timeout (and other OPA client errors) behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build-release-local-arm64: prepare
 	@docker buildx build --platform linux/arm64 -t permitio/pdp-v2:$(VERSION)$(BUILD_SUFFIX) . --load
 
 build-release-local: prepare
-	@docker build -t permitio/pdp-v2:$(VERSION)$(BUILD_SUFFIX) .
+	@docker build -t permitio/pdp-v2:$(VERSION)$(BUILD_SUFFIX) . --load
 
 run: ## Run the container locally
 	@docker run -it \

--- a/horizon/config.py
+++ b/horizon/config.py
@@ -69,6 +69,12 @@ class SidecarConfig(Confi):
         10,
     )
 
+    ALLOWED_QUERY_TIMEOUT = confi.float(
+        "ALLOWED_QUERY_TIMEOUT",
+        5 * 60,  # This is also aiohttp's default timeout
+        description="the timeout for querying OPA for an allow decision, 0 means no timeout",
+    )
+
     # internal OPA config
     OPA_CONFIG_FILE_PATH = confi.str(
         "OPA_CONFIG_FILE_PATH",

--- a/horizon/config.py
+++ b/horizon/config.py
@@ -71,8 +71,8 @@ class SidecarConfig(Confi):
 
     OPA_CLIENT_QUERY_TIMEOUT = confi.float(
         "OPA_CLIENT_QUERY_TIMEOUT",
-        5 * 60,  # This is also aiohttp's default timeout
-        description="the timeout for querying OPA for an allow decision, 0 means no timeout",
+        1,  # aiohttp's default timeout is 5m, we want to be more aggressive
+        description="the timeout for querying OPA for an allow decision, in seconds. 0 means no timeout",
     )
 
     # internal OPA config

--- a/horizon/config.py
+++ b/horizon/config.py
@@ -69,8 +69,8 @@ class SidecarConfig(Confi):
         10,
     )
 
-    ALLOWED_QUERY_TIMEOUT = confi.float(
-        "ALLOWED_QUERY_TIMEOUT",
+    OPA_CLIENT_QUERY_TIMEOUT = confi.float(
+        "OPA_CLIENT_QUERY_TIMEOUT",
         5 * 60,  # This is also aiohttp's default timeout
         description="the timeout for querying OPA for an allow decision, 0 means no timeout",
     )

--- a/horizon/enforcer/api.py
+++ b/horizon/enforcer/api.py
@@ -1,11 +1,10 @@
 import json
 import re
-from http.client import HTTPException
 from typing import cast, Optional, Union, Dict, List
 
 import aiohttp
 from fastapi import APIRouter, Depends, Header
-from fastapi import HTTPException as fastapi_HTTPException
+from fastapi import HTTPException
 from fastapi import Request, Response, status
 from opal_client.config import opal_client_config
 from opal_client.logger import logger
@@ -436,7 +435,7 @@ def init_enforcer_api_router(policy_store: BasePolicyStoreClient = None):
         x_permit_sdk_language: Optional[str] = Depends(notify_seen_sdk),
     ):
         if isinstance(query, AuthorizationQueryV1):
-            raise fastapi_HTTPException(
+            raise HTTPException(
                 status_code=status.HTTP_421_MISDIRECTED_REQUEST,
                 detail="Mismatch between client version and PDP version,"
                 " required v2 request body, got v1. "
@@ -480,7 +479,7 @@ def init_enforcer_api_router(policy_store: BasePolicyStoreClient = None):
     async def is_allowed_kong(request: Request, query: KongAuthorizationQuery):
         # Short circuit if disabled
         if sidecar_config.KONG_INTEGRATION is False:
-            raise fastapi_HTTPException(
+            raise HTTPException(
                 status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Kong integration is disabled. "
                 "Please set the PDP_KONG_INTEGRATION variable to true to enable it.",

--- a/horizon/enforcer/api.py
+++ b/horizon/enforcer/api.py
@@ -208,7 +208,7 @@ async def post_to_opa(request: Request, path: str, data: dict):
                 url,
                 data=json.dumps(data) if data is not None else None,
                 headers=headers,
-                timeout=sidecar_config.ALLOWED_QUERY_TIMEOUT,
+                timeout=sidecar_config.OPA_CLIENT_QUERY_TIMEOUT,
             ) as opa_response:
                 return await proxy_response(opa_response)
     except asyncio.exceptions.TimeoutError:
@@ -216,7 +216,7 @@ async def post_to_opa(request: Request, path: str, data: dict):
             status.HTTP_504_GATEWAY_TIMEOUT,
             detail="OPA request timed out (url: {url}, timeout: {timeout}s)".format(
                 url=url,
-                timeout=sidecar_config.ALLOWED_QUERY_TIMEOUT,
+                timeout=sidecar_config.OPA_CLIENT_QUERY_TIMEOUT,
                 raise_for_status=True,
             ),
         )

--- a/horizon/enforcer/api.py
+++ b/horizon/enforcer/api.py
@@ -208,7 +208,10 @@ async def _is_allowed(query: BaseSchema, request: Request, policy_package: str):
         logger.debug(f"calling OPA at '{url}' with input: {opa_input}")
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                url, data=json.dumps(opa_input), headers=headers
+                url,
+                data=json.dumps(opa_input),
+                headers=headers,
+                timeout=sidecar_config.ALLOWED_QUERY_TIMEOUT,
             ) as opa_response:
                 return await proxy_response(opa_response)
     except aiohttp.ClientError as e:


### PR DESCRIPTION
https://linear.app/permit/issue/PER-8115/sidecar-returns-an-error-when-opa-queries-timeout

Fixes: PER-8115

1. Introduce `PDP_OPA_CLIENT_QUERY_TIMEOUT` envar for changing the timeout on OPA queries
2. Catch TimeoutError and (return indicative 504, log warning) instead of (return 500, log giant stack trace).
3. On other OPA client errors - return indicative 502 instead of inappropriate 400 error
4. Replace accidentally used `aiohttp.HTTPException` with `fastapi.HTTPException` so the correct errors would be returned (and not generic 500)
5. Get rid of the fallback response mechanism (returning `{"allow": false}` on an error): it wasn't working anyway, and we actually want to return an error when there's an error.

