### PR TITLE
Workaround topics issue

### DIFF
--- a/horizon/pdp.py
+++ b/horizon/pdp.py
@@ -278,7 +278,6 @@ class PermitPDP:
             attempts=14,
             wait_time=1,
         )
-        opal_client_config.FETCHING_CALLBACK_TIMEOUT = 64
 
     def _fix_data_topics(self) -> List[str]:
         """

--- a/horizon/pdp.py
+++ b/horizon/pdp.py
@@ -114,6 +114,8 @@ class PermitPDP:
             # we need to pass to OPAL a custom inline OPA config to enable these features
             self._configure_inline_opa_config()
 
+        self._configure_opal_data_updater()
+
         if sidecar_config.PRINT_CONFIG_ON_STARTUP:
             logger.info(
                 "sidecar is loading with the following config:\n\n{sidecar_config}\n\n{opal_client_config}\n\n{opal_common_config}",
@@ -267,6 +269,7 @@ class PermitPDP:
                 exclude_list.remove(OPA_LOGGER_MODULE)
                 opal_common_config.LOG_MODULE_EXCLUDE_LIST = exclude_list
 
+    def _configure_opal_data_updater(self):
         # Retry 10 times with (random) exponential backoff (wait times up to 1, 2, 4, 6, 8, 16, 32, 64, 128, 256 secs), and overall timeout of 64 seconds
         opal_client_config.DATA_UPDATER_CONN_RETRY = ConnRetryOptions(
             wait_strategy="random_exponential",


### PR DESCRIPTION
This replaces that backend PR: https://github.com/permitio/permit-backend/pull/2004

It's a similar fix - changing opal-client's configured data topics to use the shorter format (without the `/{scope_id}` suffix),
Thus making the first data updater fetch of the scope's DataSourceConfig (that has the shorter format of the topic) effective.

Doing this in the sidecar itself enables us to still use the longer version in relay's PDP pings - that's important because `opal-relay` assumes the topics updates are published to perfectly match the topics the targeted PDP reports (Unfortunately `opal-relay` is unaware of the hierarchical structure of topics, in which listening to `xyz` implicitly includes listening to `xyz/{scope_id}`)